### PR TITLE
Enhance map preview and search UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,9 +6,27 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
   <style>
     body, html { margin:0; height:100% }
-    #map { width:100%; height:90% }
+    #preview {
+      position:relative;
+      width:100%;
+      aspect-ratio:17/11;
+    }
+    #map {
+      position:absolute;
+      top:0; bottom:0; left:0; right:0;
+    }
+    #title-overlay {
+      position:absolute;
+      top:10px;
+      left:50%;
+      transform:translateX(-50%);
+      text-align:center;
+      pointer-events:none;
+      font-size:18px;
+      font-weight:bold;
+      line-height:1.2;
+    }
     #controls {
-      height:10%;
       display:flex;
       align-items:center;
       gap:0.5em;
@@ -22,9 +40,17 @@
   </style>
 </head>
 <body>
-  <div id="map"></div>
+  <div id="preview">
+    <div id="map"></div>
+    <div id="title-overlay">
+      <div id="title-text"></div>
+      <div id="coord-text" style="font-size:14px;font-weight:normal"></div>
+    </div>
+  </div>
   <div id="controls">
-    <input id="search" placeholder="Search place…" />
+    <input id="search" list="suggestions" placeholder="Search place…" />
+    <datalist id="suggestions"></datalist>
+    <button id="search-btn">Search</button>
     <input id="title" placeholder="Map title…" />
     <button id="export">Export PDF</button>
   </div>


### PR DESCRIPTION
## Summary
- show a preview container with 17/11 aspect ratio
- add autocomplete and button-based search
- overlay title and coordinates on the map
- export map including overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686a8671729c832793f5dd7875792459