### PR TITLE
Add print preview layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -80,10 +80,10 @@ exportBtn.addEventListener('click', () => {
     const { jsPDF } = window.jspdf;
     const pdf = new jsPDF({
       orientation: 'landscape',
-      unit: 'pt',
-      format: [canvas.width, canvas.height]
+      unit: 'in',
+      format: [17, 11]
     });
-    pdf.addImage(canvas, 'PNG', 0, 0, canvas.width, canvas.height);
+    pdf.addImage(canvas, 'PNG', 0, 0, 17, 11);
     pdf.save('map.pdf');
   });
 });

--- a/index.html
+++ b/index.html
@@ -5,46 +5,76 @@
   <title>Minimal Map Maker</title>
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
   <style>
-    body, html { margin:0; height:100% }
+    body, html {
+      margin: 0;
+      height: 100%;
+    }
+
+    body {
+      display: flex;
+      flex-direction: column;
+      background: #ddd;
+    }
+
+    #page-container {
+      flex: 1;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      padding: 1em;
+      box-sizing: border-box;
+    }
+
     #preview {
-      position:relative;
-      width:100%;
-      aspect-ratio:17/11;
+      background: #fff;
+      box-shadow: 0 0 8px rgba(0, 0, 0, 0.3);
+      aspect-ratio: 17 / 11;
+      width: 100%;
+      max-width: 90vw;
+      display: flex;
+      flex-direction: column;
+      padding: 40px;
+      box-sizing: border-box;
+      gap: 1em;
     }
+
+    #title-text {
+      text-align: center;
+      font-size: 24px;
+      font-weight: bold;
+    }
+
     #map {
-      position:absolute;
-      top:0; bottom:0; left:0; right:0;
+      flex: 1;
+      border: 2px solid #000;
     }
-    #title-overlay {
-      position:absolute;
-      top:10px;
-      left:50%;
-      transform:translateX(-50%);
-      text-align:center;
-      pointer-events:none;
-      font-size:18px;
-      font-weight:bold;
-      line-height:1.2;
+
+    #coord-text {
+      text-align: center;
+      font-size: 14px;
     }
+
     #controls {
-      display:flex;
-      align-items:center;
-      gap:0.5em;
-      padding:0.5em;
-      background:#f8f8f8;
+      display: flex;
+      align-items: center;
+      gap: 0.5em;
+      padding: 0.5em;
+      background: #f8f8f8;
     }
-    input, button {
-      font-size:1em;
-      padding:0.3em;
+
+    input,
+    button {
+      font-size: 1em;
+      padding: 0.3em;
     }
   </style>
 </head>
 <body>
-  <div id="preview">
-    <div id="map"></div>
-    <div id="title-overlay">
+  <div id="page-container">
+    <div id="preview">
       <div id="title-text"></div>
-      <div id="coord-text" style="font-size:14px;font-weight:normal"></div>
+      <div id="map"></div>
+      <div id="coord-text"></div>
     </div>
   </div>
   <div id="controls">


### PR DESCRIPTION
## Summary
- update layout to show a paper preview with margins
- draw a neat line around the map and place the title above it
- export PDF using an 11x17 tabloid page

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_686e762bd0848327875e6af53a271b1d