### PR TITLE
Improve map orientation and header layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,6 +28,10 @@ const orientationBtn = document.getElementById('orientation-btn');
 let orientation = 'landscape';
 let lastCoords = map.getCenter();
 
+// Default placeholder title and coordinates for downtown Saint Augustine
+titleInput.value = 'Saint Augustine';
+updateOverlay(lastCoords.lat, lastCoords.lng);
+
 function toDMS(deg) {
   const d = Math.floor(Math.abs(deg));
   const minFloat = (Math.abs(deg) - d) * 60;
@@ -94,7 +98,11 @@ function updateOrientation() {
 }
 
 orientationBtn.addEventListener('click', () => {
+  const previous = orientation;
   orientation = orientation === 'landscape' ? 'portrait' : 'landscape';
+  if (previous === 'landscape' && orientation === 'portrait') {
+    map.zoomOut();
+  }
   updateOrientation();
 });
 

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
       display: flex;
       flex-direction: column;
       background: #ddd;
+      padding-top: 3.5em; /* space for fixed header */
     }
 
     #page-container {
@@ -45,6 +46,19 @@
       flex: 1;
       border: 2px solid #000;
       position: relative;
+      overflow: hidden;
+      /* fade overlay using pseudo element */
+    }
+
+    #map::after {
+      content: "";
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      height: 4em;
+      pointer-events: none;
+      background: linear-gradient(to bottom, rgba(255, 255, 255, 0), #fff);
     }
 
     #title-text,
@@ -54,6 +68,7 @@
       width: 100%;
       text-align: center;
       pointer-events: none;
+      z-index: 1001;
     }
 
     #title-text {
@@ -73,6 +88,11 @@
       gap: 0.5em;
       padding: 0.5em;
       background: #f8f8f8;
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 1000;
     }
 
     input,


### PR DESCRIPTION
## Summary
- keep controls as a fixed header
- fade the bottom of the map to white so text is readable
- show default `Saint Augustine` title and coordinates
- zoom out one level when switching to portrait orientation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687e9684e0b483278944802f72cf5a78