### PR TITLE
Improve map overlay styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
 
     #map {
       flex: 1;
-      border: 2px solid #000;
+      border: 4px solid #222;
       position: relative;
       overflow: hidden;
       /* fade overlay using pseudo element */
@@ -56,7 +56,7 @@
       left: 0;
       right: 0;
       bottom: 0;
-      height: 4em;
+      height: 20%;
       pointer-events: none;
       background: linear-gradient(to bottom, rgba(255, 255, 255, 0), #fff);
     }
@@ -72,14 +72,16 @@
     }
 
     #title-text {
-      bottom: 2.5em;
-      font-size: 24px;
-      font-weight: bold;
+      bottom: 3em;
+      font-size: clamp(32px, 5vw, 48px);
+      font-weight: 600;
+      letter-spacing: 0.05em;
     }
 
     #coord-text {
       bottom: 1em;
-      font-size: 14px;
+      font-size: clamp(12px, 2vw, 18px);
+      letter-spacing: 0.05em;
     }
 
     #controls {


### PR DESCRIPTION
## Summary
- darken the map border and enlarge it
- fade out the lower 20% of the map
- update type for a larger modern title and smaller coordinates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fd15bbb98832780b216abc578d1d2