### PR TITLE
Use Stadia Toner lines-only tiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,4 @@ This repository does not currently include automated tests. To help future agent
 ## Agent Log
 - 2024-05-22: Initial creation of `AGENTS.md` to keep a running history of changes and ideas. Remember to append future notes here.
 - 2025-08-06: Updated the application's visual style for a more modern, minimalist aesthetic. Changed the basemap to Stamen Toner for a high-contrast, black-and-white look. Switched the font to "Roboto" and adjusted text sizes to make the place name more prominent.
+- 2025-08-06: Replaced Stamen Toner basemap with Stadia Stamen Toner lines to display only street lines for an even cleaner appearance.

--- a/app.js
+++ b/app.js
@@ -4,12 +4,13 @@ const map = L.map('map', {
   attributionControl: false
 }).setView([29.89, -81.31], 13);
 
-// Minimal basemap
-L.tileLayer('https://tiles.stadiamaps.com/tiles/stamen_toner/{z}/{x}/{y}{r}.png', {
-  maxZoom: 19,
-  attribution: '&copy; <a href="https://www.stadiamaps.com/" target="_blank">Stadia Maps</a> &copy; <a href="https://www.stamen.com/" target="_blank">Stamen Design</a> &copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+// Minimal basemap: Stadia Stamen Toner lines only
+L.tileLayer('https://tiles.stadiamaps.com/tiles/stamen_toner_lines/{z}/{x}/{y}{r}.png', {
+  minZoom: 0,
+  maxZoom: 20,
+  ext: 'png',
+  attribution: '&copy; <a href="https://www.stadiamaps.com/" target="_blank">Stadia Maps</a> &copy; <a href="https://www.stamen.com/" target="_blank">Stamen Design</a> &copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 }).addTo(map);
-
 const controlsContainer = document.getElementById('controls');
 const zoomControl = L.control.zoom().addTo(map);
 const attribution = L.control.attribution().addTo(map);


### PR DESCRIPTION
## Summary
- switch base map to Stadia Stamen Toner lines to show only street lines for a cleaner look
- log change in AGENTS.md

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_6893d1b12e4083279b8edbc91453d1b8