### PR TITLE
Update map center coordinates on pan and adjust title spacing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,4 @@ This repository does not currently include automated tests. To help future agent
 - 2024-05-22: Initial creation of `AGENTS.md` to keep a running history of changes and ideas. Remember to append future notes here.
 - 2025-08-06: Updated the application's visual style for a more modern, minimalist aesthetic. Changed the basemap to Stamen Toner for a high-contrast, black-and-white look. Switched the font to "Roboto" and adjusted text sizes to make the place name more prominent.
 - 2025-08-06: Replaced Stamen Toner basemap with Stadia Stamen Toner lines to display only street lines for an even cleaner appearance.
+- 2025-08-06: Display map center coordinates during panning and lowered the title position to sit closer to the coordinate text.

--- a/app.js
+++ b/app.js
@@ -86,6 +86,12 @@ titleInput.addEventListener('input', () => {
   updateOverlay(lastCoords.lat, lastCoords.lng);
 });
 
+// Update coordinates as the map pans
+map.on('move', () => {
+  const center = map.getCenter();
+  updateOverlay(center.lat, center.lng);
+});
+
 function updateOrientation() {
   const preview = document.getElementById('preview');
   if (orientation === 'landscape') {

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
     }
 
     #title-text {
-      bottom: 2.5em;
+      bottom: 1.8em;
       font-family: 'Roboto', sans-serif;
       font-size: clamp(38px, 5vw, 52px);
       font-weight: 700;


### PR DESCRIPTION
## Summary
- Update coordinate overlay with map center while panning
- Move title closer to the coordinate text
- Log changes in AGENTS.md

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893e9f445048327891ab236e63c5ee6