### PR TITLE
Fade bottom map area to white for readability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,4 @@ This repository does not currently include automated tests. To help future agent
 - 2025-08-06: Updated the application's visual style for a more modern, minimalist aesthetic. Changed the basemap to Stamen Toner for a high-contrast, black-and-white look. Switched the font to "Roboto" and adjusted text sizes to make the place name more prominent.
 - 2025-08-06: Replaced Stamen Toner basemap with Stadia Stamen Toner lines to display only street lines for an even cleaner appearance.
 - 2025-08-06: Display map center coordinates during panning and lowered the title position to sit closer to the coordinate text.
+- 2025-08-13: Applied a white fade overlay to the bottom one-sixth of the map to improve text readability.

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
       border: 4px solid #222;
       position: relative;
       overflow: hidden;
-      /* fade overlay using pseudo element */
+      /* pseudo-element creates bottom fade for text legibility */
     }
 
     #map::after {
@@ -59,7 +59,7 @@
       left: 0;
       right: 0;
       bottom: 0;
-      height: 20%;
+      height: 16.6667%;
       pointer-events: none;
       background: linear-gradient(to bottom, rgba(255, 255, 255, 0), #fff);
     }


### PR DESCRIPTION
## Summary
- fade bottom sixth of map frame to white with a pseudo-element
- log the update in the AGENTS history

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d10a29fe48327b858f4c2929ee6d5