### PR TITLE
Refine map overlay positioning and typography

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,4 @@ This repository does not currently include automated tests. To help future agent
 - 2025-08-06: Replaced Stamen Toner basemap with Stadia Stamen Toner lines to display only street lines for an even cleaner appearance.
 - 2025-08-06: Display map center coordinates during panning and lowered the title position to sit closer to the coordinate text.
 - 2025-08-13: Applied a white fade overlay to the bottom one-sixth of the map to improve text readability.
+- 2025-08-14: Increased fade to cover the bottom fifth of the map, moved the title closer to the coordinates, and switched overlay text to the narrower Roboto Condensed font.

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <title>Minimal Map Maker</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
   <style>
     body, html {
@@ -59,7 +59,7 @@
       left: 0;
       right: 0;
       bottom: 0;
-      height: 16.6667%;
+      height: 20%;
       pointer-events: none;
       background: linear-gradient(to bottom, rgba(255, 255, 255, 0), #fff);
     }
@@ -75,18 +75,18 @@
     }
 
     #title-text {
-      bottom: 1.8em;
-      font-family: 'Roboto', sans-serif;
+      bottom: 1.4em;
+      font-family: 'Roboto Condensed', sans-serif;
       font-size: clamp(38px, 5vw, 52px);
       font-weight: 700;
-      letter-spacing: 0.05em;
+      letter-spacing: 0;
     }
 
     #coord-text {
       bottom: 1em;
-      font-family: 'Roboto', sans-serif;
+      font-family: 'Roboto Condensed', sans-serif;
       font-size: clamp(14px, 2vw, 18px);
-      letter-spacing: 0.05em;
+      letter-spacing: 0;
     }
 
     #controls {


### PR DESCRIPTION
## Summary
- extend bottom fade overlay to one-fifth of the map
- move title closer to coordinate text and swap to Roboto Condensed font
- note changes in agent log

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_689d46eb36748327b0355974ee3bb6a4