### PR TITLE
Tighten spacing between map title and coordinates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,4 @@ This repository does not currently include automated tests. To help future agent
 - 2025-08-06: Display map center coordinates during panning and lowered the title position to sit closer to the coordinate text.
 - 2025-08-13: Applied a white fade overlay to the bottom one-sixth of the map to improve text readability.
 - 2025-08-14: Increased fade to cover the bottom fifth of the map, moved the title closer to the coordinates, and switched overlay text to the narrower Roboto Condensed font.
+- 2025-08-14: Reduced the title's bottom offset to tighten spacing above the coordinate text.

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
     }
 
     #title-text {
-      bottom: 1.4em;
+      bottom: 1em;
       font-family: 'Roboto Condensed', sans-serif;
       font-size: clamp(38px, 5vw, 52px);
       font-weight: 700;


### PR DESCRIPTION
## Summary
- Reduce bottom offset for map title so it sits closer to the coordinate text
- Log spacing adjustment in AGENTS.md

## Testing
- `npm test` *(fails: ENOENT because package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d4bc00bc8832795d35918226381d7