### PR TITLE
fix: place map lines under bottom fade

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,3 +10,4 @@ This repository does not currently include automated tests. To help future agent
 - 2025-08-13: Applied a white fade overlay to the bottom one-sixth of the map to improve text readability.
 - 2025-08-14: Increased fade to cover the bottom fifth of the map, moved the title closer to the coordinates, and switched overlay text to the narrower Roboto Condensed font.
 - 2025-08-14: Reduced the title's bottom offset to tighten spacing above the coordinate text.
+- 2025-08-19: Raised bottom fade above road lines by setting pseudo-element z-index so street lines appear under the fade.

--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
       right: 0;
       bottom: 0;
       height: 20%;
+      z-index: 1000;
       pointer-events: none;
       background: linear-gradient(to bottom, rgba(255, 255, 255, 0), #fff);
     }


### PR DESCRIPTION
## Summary
- ensure road lines sit beneath bottom fade by giving the fade pseudo-element a higher z-index
- log the change in AGENTS.md

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f732c6e88327ab855723ad1efd2a