### PR TITLE
Expand map controls: basemap selector, copy/reset, zoom badge, and scale

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,4 @@ This repository does not currently include automated tests. To help future agent
 - 2025-08-21: Added a center marker overlay, geolocation quick-center button, clearer status messaging, and refreshed control styling to guide users.
 - 2025-08-22: Softened the layout with a sticky, blurred control bar and resized the map preview to better fit on screen without overwhelming the UI.
 - 2025-12-14: Removed the center marker overlay and tightened title spacing toward the coordinates per latest feedback.
+- 2025-12-16: Added basemap switching, quick copy/reset actions, zoom badge, and scale control to expand map-making tools and feedback.

--- a/index.html
+++ b/index.html
@@ -134,9 +134,31 @@
       min-width: 0;
     }
 
+    #controls select {
+      font-size: 1em;
+      padding: 0.45em 2em 0.45em 0.75em;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      background: #fff;
+      appearance: none;
+      min-width: 160px;
+    }
+
+    .select-label {
+      display: flex;
+      align-items: center;
+      gap: 0.5em;
+      padding: 0.25em 0.5em;
+      border-radius: 6px;
+      background: rgba(0, 0, 0, 0.03);
+      font-size: 0.95em;
+    }
+
     #controls input:focus,
     #controls button:focus,
-    #controls button:hover {
+    #controls button:hover,
+    #controls select:focus,
+    #controls select:hover {
       border-color: #1a73e8;
       box-shadow: 0 0 0 3px rgba(26, 115, 232, 0.15);
       outline: none;
@@ -147,6 +169,21 @@
       color: #fff;
       cursor: pointer;
       flex: 0 0 auto;
+    }
+
+    #zoom-text {
+      position: absolute;
+      top: 0.8em;
+      right: 0.9em;
+      padding: 0.35em 0.6em;
+      font-family: 'Roboto Condensed', sans-serif;
+      font-size: 0.85em;
+      letter-spacing: 0.02em;
+      background: rgba(255, 255, 255, 0.9);
+      border-radius: 999px;
+      box-shadow: 0 1px 6px rgba(0, 0, 0, 0.12);
+      z-index: 1001;
+      pointer-events: none;
     }
 
     #status {
@@ -176,6 +213,18 @@
         <button id="orientation-btn">Switch to Portrait</button>
         <button id="export">Export PDF</button>
       </div>
+      <div class="control-row">
+        <label class="select-label">
+          Basemap
+          <select id="basemap-select">
+            <option value="lines">Toner Lines</option>
+            <option value="toner">Toner</option>
+            <option value="lite">Toner Lite</option>
+          </select>
+        </label>
+        <button id="copy-coords">Copy Coordinates</button>
+        <button id="reset-btn">Reset View</button>
+      </div>
       <div id="status" class="info" aria-live="polite"></div>
     </div>
   </div>
@@ -184,6 +233,7 @@
       <div id="map">
         <div id="title-text"></div>
         <div id="coord-text"></div>
+        <div id="zoom-text"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Motivation
- Improve the map-making UI by exposing common adjustments and quick actions while composing a minimal map preview.
- Allow swapping between Stamen basemaps to get different visual styles without changing code.
- Provide immediate feedback about zoom/scale and make it easy to copy coordinates or reset the view.
- Record the change in the agent history for future reference.

### Description
- Added a control row to `index.html` with `select#basemap-select`, `button#copy-coords`, `button#reset-btn`, and `div#zoom-text` to surface new actions and a zoom badge.
- Implemented a `basemaps` collection and runtime basemap switching in `app.js`, plus handlers for copying coordinates to the clipboard and resetting the view to `defaultView`.
- Wire updates for the zoom badge (`zoomend` event) and added a map scale control via `L.control.scale({ position: 'bottomleft' })` in `app.js`.
- Updated control styling for the new `select` and zoom badge, and appended an entry to `AGENTS.md` describing the update.

### Testing
- Started a static test server using `python -m http.server` to serve the site, which launched successfully.
- Executed an automated Playwright smoke test that loaded `index.html` and saved a screenshot, which completed successfully.
- No repository unit tests exist and no additional automated test suites were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696587d3f9f88327a872f98c3ae55055)