### PR TITLE
Polish map visuals and expand basemap options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,3 +15,5 @@ This repository does not currently include automated tests. To help future agent
 - 2025-08-22: Softened the layout with a sticky, blurred control bar and resized the map preview to better fit on screen without overwhelming the UI.
 - 2025-12-14: Removed the center marker overlay and tightened title spacing toward the coordinates per latest feedback.
 - 2025-12-16: Added basemap switching, quick copy/reset actions, zoom badge, and scale control to expand map-making tools and feedback.
+- 2026-02-08: Refreshed map aesthetics with a more editorial visual theme (glassy controls, refined typography, richer framing) and expanded colorful basemap options with Alidade Smooth as the new default for more beautiful exports.
+

--- a/app.js
+++ b/app.js
@@ -9,6 +9,24 @@ const defaultView = { lat: 29.89, lng: -81.31, zoom: 13 };
 const tileAttribution = '&copy; <a href="https://www.stadiamaps.com/" target="_blank">Stadia Maps</a> &copy; <a href="https://www.stamen.com/" target="_blank">Stamen Design</a> &copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 
 const basemaps = {
+  alidade_smooth: L.tileLayer('https://tiles.stadiamaps.com/tiles/alidade_smooth/{z}/{x}/{y}{r}.png', {
+    minZoom: 0,
+    maxZoom: 20,
+    ext: 'png',
+    attribution: tileAttribution,
+  }),
+  osm_bright: L.tileLayer('https://tiles.stadiamaps.com/tiles/osm_bright/{z}/{x}/{y}{r}.png', {
+    minZoom: 0,
+    maxZoom: 20,
+    ext: 'png',
+    attribution: tileAttribution,
+  }),
+  stamen_watercolor: L.tileLayer('https://tiles.stadiamaps.com/tiles/stamen_watercolor/{z}/{x}/{y}.jpg', {
+    minZoom: 1,
+    maxZoom: 16,
+    ext: 'jpg',
+    attribution: tileAttribution,
+  }),
   lines: L.tileLayer('https://tiles.stadiamaps.com/tiles/stamen_toner_lines/{z}/{x}/{y}{r}.png', {
     minZoom: 0,
     maxZoom: 20,
@@ -29,7 +47,7 @@ const basemaps = {
   }),
 };
 
-let activeBasemap = basemaps.lines;
+let activeBasemap = basemaps.alidade_smooth;
 activeBasemap.addTo(map);
 const controlsContainer = document.getElementById('controls');
 const zoomControl = L.control.zoom().addTo(map);

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <title>Minimal Map Maker</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@600;700&family=Roboto+Condensed:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
   <style>
     body, html {
@@ -14,7 +14,7 @@
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI',
         Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue',
         Arial, sans-serif;
-      background: #f1f2f5;
+      background: radial-gradient(circle at top, #f6f7fb 0%, #e8ebf4 45%, #d8dfec 100%);
       color: #111;
     }
 
@@ -34,8 +34,8 @@
     }
 
     #preview {
-      background: #fff;
-      box-shadow: 0 0 8px rgba(0, 0, 0, 0.3);
+      background: linear-gradient(155deg, rgba(255, 255, 255, 0.94), rgba(247, 249, 255, 0.92));
+      box-shadow: 0 28px 70px rgba(21, 34, 67, 0.28), 0 4px 16px rgba(21, 34, 67, 0.16);
       aspect-ratio: 17 / 11;
       width: min(1100px, 95vw);
       max-height: calc(100vh - 240px);
@@ -44,17 +44,32 @@
       padding: clamp(20px, 3vw, 32px);
       box-sizing: border-box;
       gap: 1em;
-      border-radius: 10px;
+      border-radius: 22px;
+      border: 1px solid rgba(255, 255, 255, 0.86);
     }
 
     #map {
       flex: 1;
       min-height: 320px;
-      border: 3px solid #222;
+      border: 4px solid #121722;
       position: relative;
       overflow: hidden;
-      border-radius: 8px;
+      border-radius: 16px;
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35);
       /* pseudo-element creates bottom fade for text legibility */
+    }
+
+    #map::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      z-index: 999;
+      pointer-events: none;
+      background:
+        radial-gradient(circle at 14% 10%, rgba(255, 255, 255, 0.4), transparent 36%),
+        radial-gradient(circle at 86% 20%, rgba(255, 255, 255, 0.24), transparent 34%),
+        linear-gradient(to top, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+      mix-blend-mode: screen;
     }
 
     #map::after {
@@ -80,18 +95,22 @@
     }
 
     #title-text {
-      bottom: 1.3em;
-      font-family: 'Roboto Condensed', sans-serif;
-      font-size: clamp(38px, 5vw, 52px);
+      bottom: 1.25em;
+      font-family: 'Playfair Display', serif;
+      font-size: clamp(40px, 5.4vw, 60px);
       font-weight: 700;
-      letter-spacing: 0;
+      letter-spacing: 0.01em;
+      color: #111723;
+      text-shadow: 0 2px 0 rgba(255, 255, 255, 0.8), 0 8px 22px rgba(0, 0, 0, 0.2);
     }
 
     #coord-text {
-      bottom: 0.7em;
+      bottom: 0.62em;
       font-family: 'Roboto Condensed', sans-serif;
-      font-size: clamp(14px, 2vw, 18px);
-      letter-spacing: 0;
+      font-size: clamp(14px, 2.1vw, 18px);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: rgba(17, 23, 35, 0.86);
     }
 
     #controls {
@@ -99,10 +118,10 @@
       top: 0;
       z-index: 1000;
       padding: 0.65em clamp(1em, 3vw, 2em);
-      background: rgba(255, 255, 255, 0.92);
-      backdrop-filter: blur(8px);
-      box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
-      border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+      background: rgba(244, 247, 255, 0.8);
+      backdrop-filter: blur(12px);
+      box-shadow: 0 6px 22px rgba(35, 46, 78, 0.12);
+      border-bottom: 1px solid rgba(85, 98, 130, 0.16);
     }
 
     #controls-inner {
@@ -122,11 +141,11 @@
     #controls input,
     #controls button {
       font-size: 1em;
-      padding: 0.5em 0.75em;
-      border: 1px solid #ccc;
-      border-radius: 4px;
-      background: #fff;
-      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+      padding: 0.58em 0.85em;
+      border: 1px solid #cad1e3;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.9);
+      transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
     }
 
     #controls input {
@@ -137,9 +156,9 @@
     #controls select {
       font-size: 1em;
       padding: 0.45em 2em 0.45em 0.75em;
-      border: 1px solid #ccc;
-      border-radius: 4px;
-      background: #fff;
+      border: 1px solid #cad1e3;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.9);
       appearance: none;
       min-width: 160px;
     }
@@ -161,14 +180,16 @@
     #controls select:hover {
       border-color: #1a73e8;
       box-shadow: 0 0 0 3px rgba(26, 115, 232, 0.15);
+      transform: translateY(-1px);
       outline: none;
     }
 
     #controls button {
-      background: #111;
+      background: linear-gradient(145deg, #232e4e, #121722);
       color: #fff;
       cursor: pointer;
       flex: 0 0 auto;
+      box-shadow: 0 6px 14px rgba(16, 23, 37, 0.24);
     }
 
     #zoom-text {
@@ -179,9 +200,9 @@
       font-family: 'Roboto Condensed', sans-serif;
       font-size: 0.85em;
       letter-spacing: 0.02em;
-      background: rgba(255, 255, 255, 0.9);
+      background: rgba(255, 255, 255, 0.92);
       border-radius: 999px;
-      box-shadow: 0 1px 6px rgba(0, 0, 0, 0.12);
+      box-shadow: 0 4px 10px rgba(0, 0, 0, 0.16);
       z-index: 1001;
       pointer-events: none;
     }
@@ -217,6 +238,9 @@
         <label class="select-label">
           Basemap
           <select id="basemap-select">
+            <option value="alidade_smooth">Alidade Smooth</option>
+            <option value="osm_bright">OSM Bright</option>
+            <option value="stamen_watercolor">Stamen Watercolor</option>
             <option value="lines">Toner Lines</option>
             <option value="toner">Toner</option>
             <option value="lite">Toner Lite</option>


### PR DESCRIPTION
### Motivation
- Improve the visual quality of exported maps so they look more like designed, poster-style outputs. 
- Offer additional colorful basemap choices and a prettier default so first-load exports are attractive.

### Description
- Updated `index.html` to introduce refined typography (`Playfair Display`), a soft radial page background, an elevated/rounded preview card, stronger map frame, a subtle light-overlay (`#map::before`) and adjusted title/coordinate styling for better legibility. 
- Restyled controls to match the editorial look with pill-shaped inputs/buttons/selects, stronger focus/hover feedback, and a glassy sticky toolbar. 
- Extended `app.js` with three new basemaps (`alidade_smooth`, `osm_bright`, `stamen_watercolor`) and switched the default `activeBasemap` to `alidade_smooth`. 
- Appended a dated entry to `AGENTS.md` documenting the visual refresh and basemap changes.

### Testing
- Ran `node --check app.js` which completed successfully. 
- Started a local static server with `python -m http.server 4173` and performed an automated Playwright script to load the page and capture a screenshot, which succeeded. 
- A combined test (`node --check app.js && python -m py_compile - <<'PY'`) failed due to an invalid inline `py_compile` invocation, so the JS syntax check was run separately and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989175ae85c8327846ffd35033a4070)